### PR TITLE
Alias starting curly brace for highlighting

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1863,7 +1863,7 @@ module.exports = grammar({
       const params = seq('|', field('params', alias($.block_param_list, $.param_list)), '|')
 
       return seq(
-        $._start_of_brace_block,
+        alias($._start_of_brace_block, '{'),
         optional(params),
         optional($._statements),
         '}',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9123,8 +9123,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_start_of_brace_block"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_start_of_brace_block"
+          },
+          "named": false,
+          "value": "{"
         },
         {
           "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -19589,6 +19589,10 @@
     "named": false
   },
   {
+    "type": "{",
+    "named": false
+  },
+  {
     "type": "|",
     "named": false
   },


### PR DESCRIPTION
I'm working on using this in [helix](https://helix-editor.com). Mostly it has been modifying the [highlights file](https://github.com/helix-editor/helix/blob/master/runtime/queries/crystal/highlights.scm) that already exists. The only problem I ran into was with the opening curly braces. I added the alias here so that I could reference it in the highlights file. All the tests pass so hopefully that doesn't break anything for you.