### PR TITLE
Fix compilation for wasm.

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -102,7 +102,10 @@ typedef enum Token Token;
 /*
  * Helpful macros
  */
-#ifdef TREE_SITTER_INTERNAL_BUILD
+#ifdef __wasm
+#define DEBUG(...)
+#define ASSERT(expr)
+#elif TREE_SITTER_INTERNAL_BUILD
 #define DEBUG(...)                                                                          \
     if (getenv("TREE_SITTER_DEBUG") && strncmp(getenv("TREE_SITTER_DEBUG"), "1", 1) == 0) { \
         fprintf(stderr, __VA_ARGS__);                                                       \


### PR DESCRIPTION
I find very useful to be able to compile to wasm and test it in the browser, usually I just run:

```tree-sitter generate && tree-sitter build --wasm && tree-sitter playground -q```

![image](https://github.com/user-attachments/assets/8a03c33f-99cf-4341-a53a-127075cc8921)
